### PR TITLE
Bump logback-core from 1.1.2 to 1.2.0 in /ForestBlog

### DIFF
--- a/ForestBlog/pom.xml
+++ b/ForestBlog/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.logback-extensions</groupId>


### PR DESCRIPTION
Bumps logback-core from 1.1.2 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-core dependency-type: direct:production ...